### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/ai-chat-example/security/code-scanning/1](https://github.com/sibiraj-s/ai-chat-example/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow appears to only check out code, set up Node.js, install dependencies, and run tests (with no evidence of writing to the repository, creating issues, or modifying pull requests), the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions.  
**Change:**  
- Add the following block after the `name:` and before `on:` (e.g., after line 1):  
  ```yaml
  permissions:
    contents: read
  ```
No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
